### PR TITLE
Fix habit logging date

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -68,11 +68,11 @@ export const getCalendarSummary = async (
 };
 
 export const logHabit = async (habitId: number, date: string) => {
-  await api.post(`/habits/${habitId}/log`);
+  await api.post(`/habits/${habitId}/log`, { date });
 };
 
 export const undoHabit = async (habitId: number, date: string) => {
-  await api.post(`/habits/${habitId}/unlog`);
+  await api.post(`/habits/${habitId}/unlog`, { date });
 };
 
 export const editHabit = async (id: number, name: string) => {


### PR DESCRIPTION
## Summary
- allow logging and undoing habits for arbitrary dates
- include date in the frontend API calls

## Testing
- `python3 -m py_compile backend/app/routes/habits.py`
- `npm install`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6885f294b6f483309d23315161d567c5