### PR TITLE
Enable deep link password reset

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -132,7 +132,8 @@ def forgot_password():
     db.session.commit()
 
     # TODO: Replace this with actual email logic
-    print(f"Password reset link: http://localhost:5050/reset-password/{token}")
+    # Deep link to open the mobile app directly for password reset
+    print(f"Password reset link: habee://reset-password/{token}")
 
     return jsonify({"message": "Reset link sent to email"}), 200
 

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "Habee",
     "slug": "habee",
+    "scheme": "habee",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -1,6 +1,6 @@
 // frontend/src/navigation/AppNavigator.tsx
 import React from "react";
-import { NavigationContainer } from "@react-navigation/native";
+import { NavigationContainer, LinkingOptions } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useAuth } from "../contexts/AuthContext";
 import LoginScreen from "../screens/LoginScreen";
@@ -12,14 +12,24 @@ import EditHabitScreen from "../screens/EditHabitScreen";
 import ForgotPasswordScreen from "../screens/ForgotPasswordScreen";
 import ResetPasswordScreen from "../screens/ResetPasswordScreen";
 import NotificationSettingsScreen from "../screens/NotificationSettingsScreen";
+import * as Linking from "expo-linking";
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
+
+const linking: LinkingOptions<RootStackParamList> = {
+  prefixes: [Linking.createURL("/")],
+  config: {
+    screens: {
+      ResetPassword: "reset-password/:token",
+    },
+  },
+};
 
 export default function AppNavigator() {
   const { isLoggedIn } = useAuth();
 
   return (
-    <NavigationContainer>
+    <NavigationContainer linking={linking}>
       <Stack.Navigator screenOptions={{ headerShown: false }}>
         {isLoggedIn ? (
           <>

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -189,22 +189,11 @@ const LoginScreen = () => {
           </Text>
         )}
 
-        <Pressable onPress={() => navigation.navigate("Register")}>
-          <Text style={styles.link}>Don’t have an account? Register</Text>
+        <Pressable onPress={() => navigation.navigate("Register")}> 
+          <Text style={styles.link}>Don’t have an account? Register</Text> 
         </Pressable>
-        <Pressable onPress={() => navigation.navigate("ForgotPassword")}>
-          <Text style={styles.link}>Forgot password?</Text>
-        </Pressable>
-        <Pressable
-          onPress={() => {
-            navigation.navigate("ResetPassword", {
-              token:
-                // "your-dev-token-here"
-                "b9e6c739-9a1e-4d76-a321-2f72bacd7f25",
-            });
-          }}
-        >
-          <Text style={styles.link}>Reset Password</Text>
+        <Pressable onPress={() => navigation.navigate("ForgotPassword")}> 
+          <Text style={styles.link}>Forgot password?</Text> 
         </Pressable>
       </View>
     </KeyboardAvoidingView>


### PR DESCRIPTION
## Summary
- deep link ResetPassword screen for email navigation only
- remove testing link to ResetPassword from login
- print deep link in forgot-password endpoint for manual emails

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f944947748330a182b60fa758c1ce