### PR TITLE
Support Sign in with Apple when email is missing

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -6,6 +6,7 @@ class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
+    apple_id = db.Column(db.String(255), unique=True, nullable=True)
 
     habits = db.relationship(
     'Habit',

--- a/backend/migrations/versions/d84bcff0b9e4_add_apple_id_to_user.py
+++ b/backend/migrations/versions/d84bcff0b9e4_add_apple_id_to_user.py
@@ -1,0 +1,26 @@
+"""Add apple_id to user
+
+Revision ID: d84bcff0b9e4
+Revises: 9a4e316643ec
+Create Date: 2025-08-05 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'd84bcff0b9e4'
+down_revision = '9a4e316643ec'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('apple_id', sa.String(length=255), nullable=True))
+        batch_op.create_unique_constraint(batch_op.f('uq_user_apple_id'), ['apple_id'])
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f('uq_user_apple_id'), type_='unique')
+        batch_op.drop_column('apple_id')


### PR DESCRIPTION
## Summary
- add apple_id column to users and migration
- map Apple sign-in using apple_id when email is absent

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68950e03b6c4833087bba2571f603e26