### PR TITLE
feat: add theme toggling

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import AppNavigator from "./src/navigation/AppNavigator";
 import { AuthProvider } from "./src/contexts/AuthContext";
-import { ThemeProvider } from "./src/contexts/ThemeContext";
+import { ThemeProvider, useTheme } from "./src/contexts/ThemeContext";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 import { toastConfig } from "./src/components/ToastConfig";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import * as Notifications from "expo-notifications";
+import { StatusBar } from "react-native";
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -17,11 +18,22 @@ Notifications.setNotificationHandler({
   }),
 });
 
+const ThemedStatusBar = () => {
+  const { theme, colors } = useTheme();
+  return (
+    <StatusBar
+      barStyle={theme === "dark" ? "light-content" : "dark-content"}
+      backgroundColor={colors.background}
+    />
+  );
+};
+
 export default function App() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <ThemeProvider>
+          <ThemedStatusBar />
           <AuthProvider>
             <AppNavigator />
           </AuthProvider>

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import AppNavigator from "./src/navigation/AppNavigator";
 import { AuthProvider } from "./src/contexts/AuthContext";
+import { ThemeProvider } from "./src/contexts/ThemeContext";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 import { toastConfig } from "./src/components/ToastConfig";
@@ -20,9 +21,11 @@ export default function App() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
-        <AuthProvider>
-          <AppNavigator />
-        </AuthProvider>
+        <ThemeProvider>
+          <AuthProvider>
+            <AppNavigator />
+          </AuthProvider>
+        </ThemeProvider>
         <Toast config={toastConfig} position="top" topOffset={50} />
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/frontend/src/components/HeaderNav.tsx
+++ b/frontend/src/components/HeaderNav.tsx
@@ -6,7 +6,6 @@ import {
   Text,
   Pressable,
   StyleSheet,
-  StatusBar,
   StyleProp,
   ViewStyle,
 } from "react-native";
@@ -40,7 +39,6 @@ export default function HeaderNav({
 
   return (
     <View style={[{ backgroundColor: "#f7ce46" }, style]}>
-      <StatusBar barStyle="dark-content" backgroundColor="#f7ce46" />
       <View style={[styles.header, { paddingTop: insets.top }]}>
         <Pressable onPress={onPrev} hitSlop={10}>
           <Ionicons name="chevron-back" size={28} color="#000" />

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,61 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export type ThemeMode = "light" | "dark";
+
+interface ThemeContextProps {
+  theme: ThemeMode;
+  colors: {
+    background: string;
+    text: string;
+  };
+  toggleTheme: () => void;
+}
+
+const lightColors = {
+  background: "#fff",
+  text: "#000",
+};
+
+const darkColors = {
+  background: "#111",
+  text: "#fff",
+};
+
+const ThemeContext = createContext<ThemeContextProps>({
+  theme: "light",
+  colors: lightColors,
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [theme, setTheme] = useState<ThemeMode>("light");
+
+  useEffect(() => {
+    const loadTheme = async () => {
+      const stored = await AsyncStorage.getItem("theme");
+      if (stored === "dark") setTheme("dark");
+    };
+    loadTheme();
+  }, []);
+
+  const toggleTheme = async () => {
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    await AsyncStorage.setItem("theme", newTheme);
+  };
+
+  const colors = theme === "dark" ? darkColors : lightColors;
+
+  return (
+    <ThemeContext.Provider value={{ theme, colors, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);
+
+export const themes = { light: lightColors, dark: darkColors };

--- a/frontend/src/screens/CalendarScreen.tsx
+++ b/frontend/src/screens/CalendarScreen.tsx
@@ -7,13 +7,17 @@ import HeaderNav from "../components/HeaderNav";
 import Legend from "../components/Legend";
 import LoadingSpinner from "../components/LoadingSpinner";
 import Toast from "react-native-toast-message";
+import { useGlobalStyles } from "../styles/theme";
+import { useTheme } from "../contexts/ThemeContext";
 
 export default function CalendarScreen() {
   const [selectedMonth, setSelectedMonth] = useState(new Date());
   const [calendarData, setCalendarData] = useState<CalendarSummary>({});
   const [refreshing, setRefreshing] = useState(false);
   const [loading, setLoading] = useState(false);
-
+  const globalStyles = useGlobalStyles();
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
   const fetchSummary = async (isInitial = false) => {
     if (isInitial) setLoading(true);
     try {
@@ -50,7 +54,7 @@ export default function CalendarScreen() {
   };
 
   return (
-    <>
+    <View style={globalStyles.screen}>
       <HeaderNav
         date={selectedMonth}
         onPrev={handlePrevMonth}
@@ -71,15 +75,16 @@ export default function CalendarScreen() {
           </>
         )}
       </ScrollView>
-    </>
+    </View>
   );
 }
 
-const styles = StyleSheet.create({
-  scrollContent: {
-    flexGrow: 1,
-    justifyContent: "center",
-    paddingBottom: 100,
-    backgroundColor: "#fff",
-  },
-});
+const getStyles = (colors: { background: string }) =>
+  StyleSheet.create({
+    scrollContent: {
+      flexGrow: 1,
+      justifyContent: "center",
+      paddingBottom: 100,
+      backgroundColor: colors.background,
+    },
+  });

--- a/frontend/src/screens/CreateHabitScreen.tsx
+++ b/frontend/src/screens/CreateHabitScreen.tsx
@@ -6,12 +6,17 @@ import api from "../../lib/api";
 import PrimaryButton from "../components/PrimaryButton";
 import { isValidHabit } from "../utils/validation";
 import { AxiosError } from "axios";
+import { useGlobalStyles } from "../styles/theme";
+import { useTheme } from "../contexts/ThemeContext";
 
 export default function CreateHabitScreen() {
   const navigation = useNavigation();
   const [name, setName] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const globalStyles = useGlobalStyles();
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
 
   const handleCreateHabit = async () => {
     const { valid, error: validationError } = isValidHabit(name);
@@ -42,9 +47,9 @@ export default function CreateHabitScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[globalStyles.screen, styles.container]}>
       <View style={styles.card}>
-        <Text style={styles.label}>New Habit</Text>
+        <Text style={[globalStyles.text, styles.label]}>New Habit</Text>
         <TextInput
           style={[styles.input, error && styles.inputError]}
           value={name}
@@ -69,48 +74,47 @@ export default function CreateHabitScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 20,
-    backgroundColor: "#f2f2f2",
-  },
-  card: {
-    width: "100%",
-    backgroundColor: "#fff",
-    padding: 24,
-    borderRadius: 16,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 3,
-  },
-  label: {
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: 10,
-    color: "#000",
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: "#ccc",
-    borderRadius: 8,
-    padding: 12,
-    marginBottom: 20,
-    fontSize: 16,
-    color: "#000",
-  },
-  inputError: {
-    borderColor: "#c0392b",
-  },
-  errorMessage: {
-    color: "#c0392b",
-    fontSize: 13,
-    marginBottom: 14,
-    textAlign: "left",
-  },
-});
+const getStyles = (colors: { background: string; text: string }) =>
+  StyleSheet.create({
+    container: {
+      justifyContent: "center",
+      alignItems: "center",
+      padding: 20,
+    },
+    card: {
+      width: "100%",
+      backgroundColor: colors.background,
+      padding: 24,
+      borderRadius: 16,
+      shadowColor: "#000",
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 4,
+      elevation: 3,
+    },
+    label: {
+      fontSize: 16,
+      fontWeight: "600",
+      marginBottom: 10,
+      color: colors.text,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: "#ccc",
+      borderRadius: 8,
+      padding: 12,
+      marginBottom: 20,
+      fontSize: 16,
+      color: colors.text,
+      backgroundColor: colors.background,
+    },
+    inputError: {
+      borderColor: "#c0392b",
+    },
+    errorMessage: {
+      color: "#c0392b",
+      fontSize: 13,
+      marginBottom: 14,
+      textAlign: "left",
+    },
+  });

--- a/frontend/src/screens/EditHabitScreen.tsx
+++ b/frontend/src/screens/EditHabitScreen.tsx
@@ -5,6 +5,8 @@ import { StyleSheet, Text, TextInput, View } from "react-native";
 import { editHabit } from "../../lib/api";
 import PrimaryButton from "../components/PrimaryButton";
 import { isValidHabit } from "../utils/validation";
+import { useGlobalStyles } from "../styles/theme";
+import { useTheme } from "../contexts/ThemeContext";
 
 export default function EditHabitScreen() {
   const route = useRoute<any>();
@@ -14,6 +16,9 @@ export default function EditHabitScreen() {
   const [name, setName] = useState(currentName);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const globalStyles = useGlobalStyles();
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
 
   const handleUpdate = async () => {
     const { valid, error: validationError } = isValidHabit(name);
@@ -39,9 +44,9 @@ export default function EditHabitScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[globalStyles.screen, styles.container]}>
       <View style={styles.card}>
-        <Text style={styles.label}>Edit Habit</Text>
+        <Text style={[globalStyles.text, styles.label]}>Edit Habit</Text>
         <TextInput
           style={[styles.input, error && styles.inputError]}
           value={name}
@@ -63,44 +68,43 @@ export default function EditHabitScreen() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 20,
-    backgroundColor: "#f2f2f2",
-  },
-  card: {
-    width: "100%",
-    backgroundColor: "#fff",
-    padding: 24,
-    borderRadius: 16,
-    elevation: 3,
-  },
-  label: {
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: 10,
-    color: "#000",
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: "#ccc",
-    borderRadius: 8,
-    padding: 12,
-    marginBottom: 20,
-    fontSize: 16,
-    color: "#000",
-  },
-  inputError: {
-    borderColor: "#c0392b",
-  },
-  errorMessage: {
-    color: "#c0392b",
-    fontSize: 13,
-    marginBottom: 14,
-    textAlign: "left",
-  },
-});
+const getStyles = (colors: { background: string; text: string }) =>
+  StyleSheet.create({
+    container: {
+      justifyContent: "center",
+      alignItems: "center",
+      padding: 20,
+    },
+    card: {
+      width: "100%",
+      backgroundColor: colors.background,
+      padding: 24,
+      borderRadius: 16,
+      elevation: 3,
+    },
+    label: {
+      fontSize: 16,
+      fontWeight: "600",
+      marginBottom: 10,
+      color: colors.text,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: "#ccc",
+      borderRadius: 8,
+      padding: 12,
+      marginBottom: 20,
+      fontSize: 16,
+      color: colors.text,
+      backgroundColor: colors.background,
+    },
+    inputError: {
+      borderColor: "#c0392b",
+    },
+    errorMessage: {
+      color: "#c0392b",
+      fontSize: 13,
+      marginBottom: 14,
+      textAlign: "left",
+    },
+  });

--- a/frontend/src/screens/ForgotPasswordScreen.tsx
+++ b/frontend/src/screens/ForgotPasswordScreen.tsx
@@ -15,6 +15,8 @@ import Toast from "react-native-toast-message";
 import { isValidEmail } from "../utils/validation";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { RootStackParamList } from "../../types";
+import { useGlobalStyles } from "../styles/theme";
+import { useTheme } from "../contexts/ThemeContext";
 
 type NavigationProp = NativeStackNavigationProp<
   RootStackParamList,
@@ -26,6 +28,9 @@ export default function ForgotPasswordScreen() {
   const [loading, setLoading] = useState(false);
 
   const navigation = useNavigation<NavigationProp>();
+  const globalStyles = useGlobalStyles();
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
 
   const handleSubmit = async () => {
     if (!isValidEmail(email)) {
@@ -59,13 +64,13 @@ export default function ForgotPasswordScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[globalStyles.screen, styles.container]}>
       {/* Back Button */}
       <Pressable onPress={() => navigation.goBack()} style={styles.backButton}>
-        <Ionicons name="arrow-back" size={24} color="#000" />
+        <Ionicons name="arrow-back" size={24} color={colors.text} />
       </Pressable>
 
-      <Text style={styles.heading}>Forgot Password</Text>
+      <Text style={[globalStyles.text, styles.heading]}>Forgot Password</Text>
 
       <TextInput
         style={styles.input}
@@ -87,13 +92,12 @@ export default function ForgotPasswordScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: "center",
-    padding: 24,
-    backgroundColor: "#f9f9f9",
-  },
+const getStyles = (colors: { background: string; text: string }) =>
+  StyleSheet.create({
+    container: {
+      justifyContent: "center",
+      padding: 24,
+    },
   backButton: {
     position: "absolute",
     top: Platform.OS === "ios" ? 60 : 30,
@@ -105,7 +109,7 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     textAlign: "center",
     marginBottom: 20,
-    color: "#000",
+    color: colors.text,
   },
   input: {
     height: 50,
@@ -114,8 +118,8 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     paddingHorizontal: 16,
     marginBottom: 20,
-    backgroundColor: "#fff",
-    color: "#000",
+    backgroundColor: colors.background,
+    color: colors.text,
     fontSize: 16,
   },
 });

--- a/frontend/src/screens/GridScreen.tsx
+++ b/frontend/src/screens/GridScreen.tsx
@@ -15,6 +15,8 @@ import { getLayoutConstants } from "../constants/layout";
 import { usePaginatedHabits } from "../hooks/usePaginatedHabits";
 import LoadingSpinner from "../components/LoadingSpinner";
 import Toast from "react-native-toast-message";
+import { useGlobalStyles } from "../styles/theme";
+import { useTheme } from "../contexts/ThemeContext";
 
 export default function GridScreen() {
   const [selectedMonth, setSelectedMonth] = useState(new Date());
@@ -24,6 +26,9 @@ export default function GridScreen() {
   const [loading, setLoading] = useState(false);
   const [expandedHabitId, setExpandedHabitId] = useState<number | null>(null);
   const [error, setError] = useState(false);
+  const globalStyles = useGlobalStyles();
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
 
   const { pageCount, habitsToDisplay } = usePaginatedHabits(
     habits,
@@ -78,7 +83,7 @@ export default function GridScreen() {
   };
 
   return (
-    <>
+    <View style={globalStyles.screen}>
       <HeaderNav
         date={selectedMonth}
         onPrev={handlePrevMonth}
@@ -88,14 +93,14 @@ export default function GridScreen() {
         <LoadingSpinner />
       ) : error ? (
         <View style={[styles.container, styles.centered]}>
-          <Text style={styles.emptyText}>
+          <Text style={[globalStyles.text, styles.emptyText]}>
             Failed to load your habits. Please try again.
           </Text>
           <Pressable
             onPress={() => fetchHabits(true)}
             style={styles.retryButton}
           >
-            <Text style={styles.retryButtonText}>Retry</Text>
+            <Text style={[globalStyles.text, styles.retryButtonText]}>Retry</Text>
           </Pressable>
         </View>
       ) : (
@@ -160,7 +165,7 @@ export default function GridScreen() {
                 dayLabelWidth={dayLabelWidth}
               />
             ) : (
-              <Text style={styles.emptyText}>
+              <Text style={[globalStyles.text, styles.emptyText]}>
                 No habits to display. Add habits to view your monthly progress.
               </Text>
             )}
@@ -178,67 +183,70 @@ export default function GridScreen() {
           )}
         </View>
       )}
-    </>
+    </View>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-  },
-  scrollContent: {
-    flexGrow: 1,
-    justifyContent: "center",
-  },
-  emptyText: {
-    fontSize: 16,
-    color: "#777",
-    textAlign: "center",
-    paddingHorizontal: 20,
-    marginTop: 20,
-    lineHeight: 24,
-  },
-  headerRow: {
-    flexDirection: "row",
-    backgroundColor: "#fff",
-    marginHorizontal: 8,
-    zIndex: 10,
-  },
-  gridContent: {
-    flexDirection: "row",
-    justifyContent: "center",
-  },
-  stickyLeftColumn: {
-    backgroundColor: "#fff",
-    zIndex: 10,
-  },
-  row: { flexDirection: "row" },
-  cell: {
-    justifyContent: "center",
-    alignItems: "center",
-    borderRadius: 6,
-    margin: 2,
-    borderColor: "grey",
-  },
-  headerCell: { backgroundColor: "#fff" },
-  dateCell: { borderTopWidth: 0 },
-  headerText: {
-    fontSize: 12,
-    fontWeight: "700",
-    textAlign: "center",
-  },
-  habitName: {
-    fontSize: 10,
-    fontWeight: "600",
-    textAlign: "center",
-    paddingHorizontal: 1,
-  },
-  dayLabelText: {
-    fontSize: 14,
-    fontWeight: "500",
-    textAlign: "center",
-  },
+const getStyles = (colors: { background: string; text: string }) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    scrollContent: {
+      flexGrow: 1,
+      justifyContent: "center",
+    },
+    emptyText: {
+      fontSize: 16,
+      color: colors.text,
+      textAlign: "center",
+      paddingHorizontal: 20,
+      marginTop: 20,
+      lineHeight: 24,
+    },
+    headerRow: {
+      flexDirection: "row",
+      backgroundColor: colors.background,
+      marginHorizontal: 8,
+      zIndex: 10,
+    },
+    gridContent: {
+      flexDirection: "row",
+      justifyContent: "center",
+    },
+    stickyLeftColumn: {
+      backgroundColor: colors.background,
+      zIndex: 10,
+    },
+    row: { flexDirection: "row" },
+    cell: {
+      justifyContent: "center",
+      alignItems: "center",
+      borderRadius: 6,
+      margin: 2,
+      borderColor: "grey",
+    },
+    headerCell: { backgroundColor: colors.background },
+    dateCell: { borderTopWidth: 0 },
+    headerText: {
+      fontSize: 12,
+      fontWeight: "700",
+      textAlign: "center",
+    },
+    habitName: {
+      fontSize: 10,
+      fontWeight: "600",
+      textAlign: "center",
+      paddingHorizontal: 1,
+      color: colors.text,
+    },
+    dayLabelText: {
+      fontSize: 14,
+      fontWeight: "500",
+      textAlign: "center",
+      color: colors.text,
+    },
   fabLeft: {
     position: "absolute",
     bottom: 30,
@@ -268,6 +276,7 @@ const styles = StyleSheet.create({
   navText: {
     fontSize: 20,
     fontWeight: "600",
+    color: colors.text,
   },
   centered: {
     justifyContent: "center",
@@ -284,6 +293,6 @@ const styles = StyleSheet.create({
   retryButtonText: {
     fontSize: 16,
     fontWeight: "600",
-    color: "#000",
+    color: colors.text,
   },
 });

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -28,6 +28,8 @@ import HeaderNav from "../components/HeaderNav";
 import LoadingSpinner from "../components/LoadingSpinner";
 import PrimaryButton from "../components/PrimaryButton";
 import SwipeableDayView from "../components/SwipeableView";
+import { useGlobalStyles } from "../styles/theme";
+import { useTheme } from "../contexts/ThemeContext";
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, "Main">;
 
@@ -41,6 +43,9 @@ export default function Home() {
   const [error, setError] = useState(false);
 
   const navigation = useNavigation<NavigationProp>();
+  const globalStyles = useGlobalStyles();
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
 
   const loadHabits = async (isInitial = false, givenDate = date) => {
     if (isInitial) setLoading(true);
@@ -135,7 +140,7 @@ export default function Home() {
   };
 
   return (
-    <>
+    <View style={globalStyles.screen}>
       <HeaderNav
         date={date}
         onPrev={goToPrevDay}
@@ -150,7 +155,7 @@ export default function Home() {
           }
         >
           <View style={styles.innerContainer}>
-            <Text style={styles.objectivesTitle}>
+            <Text style={[globalStyles.text, styles.objectivesTitle]}>
               {format(date, "EEEE")} Habits
             </Text>
 
@@ -158,7 +163,7 @@ export default function Home() {
               <LoadingSpinner size="large" />
             ) : error ? (
               <View style={styles.emptyWrapper}>
-                <Text style={styles.emptyText}>
+                <Text style={[globalStyles.text, styles.emptyText]}>
                   Failed to load habits. Please try again.
                 </Text>
                 <PrimaryButton
@@ -178,7 +183,7 @@ export default function Home() {
               ))
             ) : (
               <View style={styles.emptyWrapper}>
-                <Text style={styles.emptyText}>
+                <Text style={[globalStyles.text, styles.emptyText]}>
                   You haven’t added any habits yet.{"\n"}Tap the + button below
                   to get started.
                 </Text>
@@ -192,7 +197,7 @@ export default function Home() {
         style={styles.fab}
         onPress={() => navigation.navigate("CreateHabit")}
       >
-        <Ionicons name="create-outline" size={32} color="black" />
+        <Ionicons name="create-outline" size={32} color={colors.text} />
       </Pressable>
 
       {showHabitMenu !== null && (
@@ -212,34 +217,35 @@ export default function Home() {
           deleting={deletingId === showHabitMenu}
         />
       )}
-    </>
+    </View>
   );
 }
 
-const styles = StyleSheet.create({
-  scrollContent: {
-    flexGrow: 1,
-    paddingBottom: 100,
-    backgroundColor: "#fff",
-  },
-  innerContainer: {
-    paddingHorizontal: 20,
-    minHeight: "100%",
-  },
-  objectivesTitle: {
-    fontSize: 24,
-    fontWeight: "700",
-    marginBottom: 16,
-    marginTop: 20,
-    color: "#000",
-    textAlign: "center",
-    backgroundColor: "#fff",
-  },
-  fab: {
-    position: "absolute",
-    bottom: 30,
-    right: 20,
-    backgroundColor: "#f7ce46",
+const getStyles = (colors: { background: string; text: string }) =>
+  StyleSheet.create({
+    scrollContent: {
+      flexGrow: 1,
+      paddingBottom: 100,
+      backgroundColor: colors.background,
+    },
+    innerContainer: {
+      paddingHorizontal: 20,
+      minHeight: "100%",
+    },
+    objectivesTitle: {
+      fontSize: 24,
+      fontWeight: "700",
+      marginBottom: 16,
+      marginTop: 20,
+      color: colors.text,
+      textAlign: "center",
+      backgroundColor: colors.background,
+    },
+    fab: {
+      position: "absolute",
+      bottom: 30,
+      right: 20,
+      backgroundColor: "#f7ce46",
     padding: 16,
     borderRadius: 30,
     elevation: 5,
@@ -259,7 +265,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   menuBox: {
-    backgroundColor: "white",
+    backgroundColor: colors.background,
     padding: 24,
     borderRadius: 16,
     width: 300,

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -20,6 +20,8 @@ import { isValidEmail } from "../utils/validation";
 import { requestNotificationPermissions } from "../../lib/requestNotificationPermissions";
 import { DEV_USER, DEV_PASSWORD } from "@env";
 import * as AppleAuthentication from "expo-apple-authentication";
+import { useGlobalStyles } from "../styles/theme";
+import { useTheme } from "../contexts/ThemeContext";
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, "Main">;
 
@@ -31,6 +33,9 @@ const LoginScreen = () => {
 
   const navigation = useNavigation<NavigationProp>();
   const { login } = useAuth();
+  const globalStyles = useGlobalStyles();
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
 
   const handleLogin = async () => {
     if (!isValidEmail(email)) {
@@ -104,11 +109,11 @@ const LoginScreen = () => {
 
   return (
     <KeyboardAvoidingView
-      style={styles.container}
+      style={[globalStyles.screen, styles.container]}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
       <View style={styles.card}>
-        <Text style={styles.title}>Habee</Text>
+        <Text style={[globalStyles.text, styles.title]}>Habee</Text>
 
         <TextInput
           style={styles.input}
@@ -157,91 +162,90 @@ const LoginScreen = () => {
         )}
 
         {loading && (
-          <Text style={styles.wakeNotice}>
+          <Text style={[globalStyles.text, styles.wakeNotice]}>
             First load may take up to a minute if the server is waking up.
           </Text>
         )}
 
         <Pressable onPress={() => navigation.navigate("Register")}>
-          <Text style={styles.link}>Don’t have an account? Register</Text>
+          <Text style={[globalStyles.text, styles.link]}>Don’t have an account? Register</Text>
         </Pressable>
         <Pressable onPress={() => navigation.navigate("ForgotPassword")}>
-          <Text style={styles.link}>Forgot password?</Text>
+          <Text style={[globalStyles.text, styles.link]}>Forgot password?</Text>
         </Pressable>
       </View>
     </KeyboardAvoidingView>
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#f9f9f9",
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: 20,
-  },
-  card: {
-    width: "100%",
-    backgroundColor: "#ffffff",
-    borderRadius: 12,
-    padding: 24,
-    shadowColor: "#000",
-    shadowOpacity: 0.1,
-    shadowRadius: 10,
-  },
-  title: {
-    color: "#000",
-    fontSize: 24,
-    fontWeight: "600",
-    marginBottom: 24,
-    textAlign: "center",
-  },
-  input: {
-    height: 50,
-    backgroundColor: "#f2f2f2",
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: "#dcdcdc",
-    paddingHorizontal: 16,
-    color: "#000",
-    marginBottom: 16,
-    fontSize: 16,
-  },
-  passwordWrapper: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: "#f2f2f2",
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: "#dcdcdc",
-    paddingHorizontal: 16,
-    marginBottom: 16,
-  },
-  passwordInput: {
-    flex: 1,
-    height: 50,
-    color: "#000",
-    fontSize: 16,
-  },
-  wakeNotice: {
-    marginTop: 12,
-    fontSize: 13,
-    color: "#666",
-    textAlign: "center",
-    lineHeight: 18,
-  },
-  link: {
-    color: "#000",
-    textAlign: "center",
-    marginTop: 16,
-    fontWeight: "500",
-  },
-  appleButton: {
-    width: "100%",
-    height: 44,
-    marginVertical: 6,
-  },
-});
+const getStyles = (colors: { background: string; text: string }) =>
+  StyleSheet.create({
+    container: {
+      justifyContent: "center",
+      alignItems: "center",
+      paddingHorizontal: 20,
+    },
+    card: {
+      width: "100%",
+      backgroundColor: colors.background,
+      borderRadius: 12,
+      padding: 24,
+      shadowColor: "#000",
+      shadowOpacity: 0.1,
+      shadowRadius: 10,
+    },
+    title: {
+      color: colors.text,
+      fontSize: 24,
+      fontWeight: "600",
+      marginBottom: 24,
+      textAlign: "center",
+    },
+    input: {
+      height: 50,
+      backgroundColor: colors.background,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: "#dcdcdc",
+      paddingHorizontal: 16,
+      color: colors.text,
+      marginBottom: 16,
+      fontSize: 16,
+    },
+    passwordWrapper: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.background,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: "#dcdcdc",
+      paddingHorizontal: 16,
+      marginBottom: 16,
+    },
+    passwordInput: {
+      flex: 1,
+      height: 50,
+      color: colors.text,
+      fontSize: 16,
+    },
+    wakeNotice: {
+      marginTop: 12,
+      fontSize: 13,
+      color: colors.text,
+      textAlign: "center",
+      lineHeight: 18,
+    },
+    link: {
+      color: colors.text,
+      textAlign: "center",
+      marginTop: 16,
+      fontWeight: "500",
+    },
+    appleButton: {
+      width: "100%",
+      height: 44,
+      marginVertical: 6,
+    },
+  });
 
 export default LoginScreen;

--- a/frontend/src/screens/NotificationSettingsScreen.tsx
+++ b/frontend/src/screens/NotificationSettingsScreen.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../lib/notifications";
 import PrimaryButton from "../components/PrimaryButton";
 import { useGlobalStyles } from "../styles/theme";
+import { useTheme } from "../contexts/ThemeContext";
 
 export default function NotificationSettingsScreen() {
   const [reminderEnabled, setReminderEnabled] = useState(false);
@@ -26,6 +27,7 @@ export default function NotificationSettingsScreen() {
   const [pendingTime, setPendingTime] = useState<Date | null>(null);
   const [editing, setEditing] = useState(false);
   const globalStyles = useGlobalStyles();
+  const { theme, colors } = useTheme();
   const styles = getStyles();
 
   useEffect(() => {
@@ -98,6 +100,8 @@ export default function NotificationSettingsScreen() {
                 is24Hour={false}
                 display={Platform.OS === "ios" ? "spinner" : "default"}
                 onChange={handleTimeChange}
+                themeVariant={theme}
+                textColor={colors.text}
               />
 
               {pendingTime && (

--- a/frontend/src/screens/NotificationSettingsScreen.tsx
+++ b/frontend/src/screens/NotificationSettingsScreen.tsx
@@ -18,12 +18,15 @@ import {
   scheduleDailyReminder,
 } from "../../lib/notifications";
 import PrimaryButton from "../components/PrimaryButton";
+import { useGlobalStyles } from "../styles/theme";
 
 export default function NotificationSettingsScreen() {
   const [reminderEnabled, setReminderEnabled] = useState(false);
   const [selectedTime, setSelectedTime] = useState(new Date());
   const [pendingTime, setPendingTime] = useState<Date | null>(null);
   const [editing, setEditing] = useState(false);
+  const globalStyles = useGlobalStyles();
+  const styles = getStyles();
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -76,9 +79,9 @@ export default function NotificationSettingsScreen() {
   }, []);
 
   return (
-    <View style={styles.container}>
+    <View style={[globalStyles.screen, styles.container]}>
       <View style={styles.row}>
-        <Text style={styles.title}>Daily Reminder</Text>
+        <Text style={[globalStyles.text, styles.title]}>Daily Reminder</Text>
         <Switch value={reminderEnabled} onValueChange={handleToggleReminder} />
       </View>
 
@@ -86,7 +89,7 @@ export default function NotificationSettingsScreen() {
         <>
           {editing ? (
             <>
-              <Text style={styles.label}>
+              <Text style={[globalStyles.text, styles.label]}>
                 Pick a time for your daily reminder:
               </Text>
               <DateTimePicker
@@ -129,9 +132,9 @@ export default function NotificationSettingsScreen() {
             </>
           ) : (
             <>
-              <Text style={styles.label}>
+              <Text style={[globalStyles.text, styles.label]}>
                 Daily reminder time:{" "}
-                <Text style={styles.timeText}>
+                <Text style={[globalStyles.text, styles.timeText]}>
                   {selectedTime.toLocaleTimeString([], {
                     hour: "2-digit",
                     minute: "2-digit",
@@ -151,33 +154,30 @@ export default function NotificationSettingsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: "#fff",
-    paddingHorizontal: 20,
-    paddingTop: 40,
-    paddingBottom: 40,
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-  },
-  row: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 20,
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: "600",
-    color: "#000",
-  },
-  label: {
-    fontSize: 16,
-    color: "#333",
-    marginBottom: 10,
-  },
-  timeText: {
-    fontWeight: "600",
-    color: "#000",
-  },
-});
+const getStyles = () =>
+  StyleSheet.create({
+    container: {
+      paddingHorizontal: 20,
+      paddingTop: 40,
+      paddingBottom: 40,
+      borderTopLeftRadius: 20,
+      borderTopRightRadius: 20,
+    },
+    row: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      marginBottom: 20,
+    },
+    title: {
+      fontSize: 20,
+      fontWeight: "600",
+    },
+    label: {
+      fontSize: 16,
+      marginBottom: 10,
+    },
+    timeText: {
+      fontWeight: "600",
+    },
+  });

--- a/frontend/src/screens/RegisterScreen.tsx
+++ b/frontend/src/screens/RegisterScreen.tsx
@@ -16,6 +16,8 @@ import { useAuth } from "../contexts/AuthContext";
 import { isValidEmail, isValidPassword } from "../utils/validation";
 import Toast from "react-native-toast-message";
 import { requestNotificationPermissions } from "../../lib/requestNotificationPermissions";
+import { useGlobalStyles } from "../styles/theme";
+import { useTheme } from "../contexts/ThemeContext";
 
 export default function RegisterScreen({ navigation }: { navigation: any }) {
   const [email, setEmail] = useState("");
@@ -29,6 +31,9 @@ export default function RegisterScreen({ navigation }: { navigation: any }) {
   const [confirmError, setConfirmError] = useState<string | null>(null);
 
   const { register } = useAuth();
+  const globalStyles = useGlobalStyles();
+  const { colors } = useTheme();
+  const styles = getStyles(colors);
 
   const handleRegister = async () => {
     let valid = true;
@@ -91,7 +96,7 @@ export default function RegisterScreen({ navigation }: { navigation: any }) {
 
   return (
     <KeyboardAvoidingView
-      style={{ flex: 1 }}
+      style={globalStyles.screen}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
       <ScrollView
@@ -99,7 +104,7 @@ export default function RegisterScreen({ navigation }: { navigation: any }) {
         keyboardShouldPersistTaps="handled"
       >
         <View style={styles.card}>
-          <Text style={styles.title}>Register</Text>
+          <Text style={[globalStyles.text, styles.title]}>Register</Text>
 
           <TextInput
             style={[styles.input, emailError && styles.inputError]}
@@ -138,9 +143,9 @@ export default function RegisterScreen({ navigation }: { navigation: any }) {
           )}
 
           <View style={styles.requirementsList}>
-            <Text style={styles.requirementsItem}>• At least 6 characters</Text>
-            <Text style={styles.requirementsItem}>• 1 capital letter</Text>
-            <Text style={styles.requirementsItem}>• 1 number</Text>
+            <Text style={[globalStyles.text, styles.requirementsItem]}>• At least 6 characters</Text>
+            <Text style={[globalStyles.text, styles.requirementsItem]}>• 1 capital letter</Text>
+            <Text style={[globalStyles.text, styles.requirementsItem]}>• 1 number</Text>
           </View>
 
           <View style={styles.passwordWrapper}>
@@ -173,101 +178,99 @@ export default function RegisterScreen({ navigation }: { navigation: any }) {
           />
 
           {loading && (
-            <Text style={styles.wakeNotice}>
+            <Text style={[globalStyles.text, styles.wakeNotice]}>
               First load may take up to a minute if the server is waking up.
             </Text>
           )}
 
           <Pressable onPress={() => navigation.navigate("Login")}>
-            <Text style={styles.link}>Already have an account? Log in</Text>
+            <Text style={[globalStyles.text, styles.link]}>Already have an account? Log in</Text>
           </Pressable>
         </View>
       </ScrollView>
     </KeyboardAvoidingView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#f9f9f9",
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: 20,
-  },
-  card: {
-    width: "100%",
-    backgroundColor: "#ffffff",
-    borderRadius: 12,
-    padding: 24,
-    shadowColor: "#000",
-    shadowOpacity: 0.1,
-    shadowRadius: 10,
-  },
-  title: {
-    color: "#000",
-    fontSize: 24,
-    fontWeight: "600",
-    marginBottom: 24,
-    textAlign: "center",
-  },
-  input: {
-    height: 50,
-    backgroundColor: "#f2f2f2",
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: "#dcdcdc",
-    paddingHorizontal: 16,
-    color: "#000",
-    marginBottom: 16,
-    fontSize: 16,
-  },
-  inputError: {
-    borderColor: "#c0392b",
-  },
-  passwordWrapper: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: "#f2f2f2",
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: "#dcdcdc",
-    paddingHorizontal: 16,
-    marginBottom: 16,
-  },
-  passwordInput: {
-    flex: 1,
-    height: 50,
-    color: "#000",
-    fontSize: 16,
-  },
-  requirementsList: {
-    marginBottom: 16,
-    paddingLeft: 8,
-  },
-  requirementsItem: {
-    fontSize: 14,
-    color: "#222",
-    lineHeight: 18,
-  },
-  errorMessage: {
-    color: "#c0392b",
-    textAlign: "left",
-    fontSize: 13,
-    lineHeight: 18,
-    marginBottom: 10,
-  },
-  wakeNotice: {
-    marginTop: 12,
-    fontSize: 13,
-    color: "#666",
-    textAlign: "center",
-    lineHeight: 18,
-  },
-  link: {
-    color: "#000",
-    textAlign: "center",
-    marginTop: 16,
-    fontWeight: "500",
-  },
-});
+const getStyles = (colors: { background: string; text: string }) =>
+  StyleSheet.create({
+    container: {
+      justifyContent: "center",
+      alignItems: "center",
+      paddingHorizontal: 20,
+    },
+    card: {
+      width: "100%",
+      backgroundColor: colors.background,
+      borderRadius: 12,
+      padding: 24,
+      shadowColor: "#000",
+      shadowOpacity: 0.1,
+      shadowRadius: 10,
+    },
+    title: {
+      color: colors.text,
+      fontSize: 24,
+      fontWeight: "600",
+      marginBottom: 24,
+      textAlign: "center",
+    },
+    input: {
+      height: 50,
+      backgroundColor: colors.background,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: "#dcdcdc",
+      paddingHorizontal: 16,
+      color: colors.text,
+      marginBottom: 16,
+      fontSize: 16,
+    },
+    inputError: {
+      borderColor: "#c0392b",
+    },
+    passwordWrapper: {
+      flexDirection: "row",
+      alignItems: "center",
+      backgroundColor: colors.background,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: "#dcdcdc",
+      paddingHorizontal: 16,
+      marginBottom: 16,
+    },
+    passwordInput: {
+      flex: 1,
+      height: 50,
+      color: colors.text,
+      fontSize: 16,
+    },
+    requirementsList: {
+      marginBottom: 16,
+      paddingLeft: 8,
+    },
+    requirementsItem: {
+      fontSize: 14,
+      color: colors.text,
+      lineHeight: 18,
+    },
+    errorMessage: {
+      color: "#c0392b",
+      textAlign: "left",
+      fontSize: 13,
+      lineHeight: 18,
+      marginBottom: 10,
+    },
+    wakeNotice: {
+      marginTop: 12,
+      fontSize: 13,
+      color: colors.text,
+      textAlign: "center",
+      lineHeight: 18,
+    },
+    link: {
+      color: colors.text,
+      textAlign: "center",
+      marginTop: 16,
+      fontWeight: "500",
+    },
+  });

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -13,6 +13,8 @@ import {
 import { RootStackParamList } from "../../types";
 import PrimaryButton from "../components/PrimaryButton";
 import { useAuth } from "../contexts/AuthContext";
+import { useTheme } from "../contexts/ThemeContext";
+import { useGlobalStyles } from "../styles/theme";
 import Toast from "react-native-toast-message";
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, "Main">;
@@ -21,6 +23,9 @@ export default function SettingsScreen() {
   const [loadingDelete, setLoadingDelete] = useState(false);
   const { logout, deleteAccount } = useAuth();
   const navigation = useNavigation<NavigationProp>();
+  const { theme, colors, toggleTheme } = useTheme();
+  const globalStyles = useGlobalStyles();
+  const styles = getStyles(colors);
 
   const handleLogout = async () => {
     try {
@@ -77,14 +82,25 @@ export default function SettingsScreen() {
     );
   };
 
+  const handleToggleTheme = () => {
+    Alert.alert("Toggle Theme", "", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: theme === "light" ? "Enable dark mode" : "Enable light mode",
+        onPress: toggleTheme,
+      },
+    ]);
+  };
+
   return (
     <ScrollView
       contentContainerStyle={styles.scrollContent}
-      style={styles.container}
+      style={[globalStyles.screen, styles.container]}
     >
       <View>
-        <Text style={styles.title}>Settings</Text>
+        <Text style={[globalStyles.text, styles.title]}>Settings</Text>
 
+        <PrimaryButton title="Toggle Theme" onPress={handleToggleTheme} />
         <PrimaryButton
           title="Notifications"
           onPress={() => {
@@ -104,44 +120,39 @@ export default function SettingsScreen() {
       </View>
 
       <View>
-        <Text style={styles.versionText}>
-          Version {Constants.manifest?.version || "1.0.0"}
-        </Text>
+        <Text style={[globalStyles.text, styles.versionText]}>Version {Constants.manifest?.version || "1.0.0"}</Text>
       </View>
     </ScrollView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-    paddingTop: 80,
-    paddingHorizontal: 20,
-  },
-  scrollContent: {
-    flexGrow: 1,
-    justifyContent: "space-between",
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: "600",
-    color: "#000",
-    marginBottom: 30,
-  },
-  deleteButton: {
-    backgroundColor: "#fff",
-    borderWidth: 1,
-    borderColor: "#e0e0e0",
-    marginTop: 16,
-  },
-  versionText: {
-    // display: "flex",
-    // justifyContent: "flex-end",
-    textAlign: "center",
-    fontSize: 14,
-    color: "#999",
-    marginTop: 40,
-    marginBottom: 20,
-  },
-});
+const getStyles = (colors: { background: string; text: string }) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      paddingTop: 80,
+      paddingHorizontal: 20,
+    },
+    scrollContent: {
+      flexGrow: 1,
+      justifyContent: "space-between",
+    },
+    title: {
+      fontSize: 28,
+      fontWeight: "600",
+      marginBottom: 30,
+    },
+    deleteButton: {
+      backgroundColor: colors.background,
+      borderWidth: 1,
+      borderColor: "#e0e0e0",
+      marginTop: 16,
+    },
+    versionText: {
+      textAlign: "center",
+      fontSize: 14,
+      color: "#999",
+      marginTop: 40,
+      marginBottom: 20,
+    },
+  });

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from "react-native";
+import { useTheme } from "../contexts/ThemeContext";
+
+export const useGlobalStyles = () => {
+  const { colors } = useTheme();
+  return StyleSheet.create({
+    screen: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    text: {
+      color: colors.text,
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add ThemeContext and global styles to centralize background and text colors
- wrap app in ThemeProvider and introduce toggle button on settings screen
- persist user's theme choice with AsyncStorage and apply across screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6896733b81f88330896c689f21c16ac6