### PR TITLE
Add habit archiving with pause windows and archived list

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,3 +2,4 @@ from .user import User
 from .habit import Habit
 from .log import HabitLog
 from .reset_token import PasswordResetToken
+from .habit_pause import HabitPause

--- a/backend/app/models/habit.py
+++ b/backend/app/models/habit.py
@@ -1,6 +1,7 @@
 # backend/app/models/habit.py
 from datetime import date
 from app.extensions import db
+from .habit_pause import HabitPause
 
 class Habit(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -9,3 +10,4 @@ class Habit(db.Model):
     start_date = db.Column(db.Date, default=date.today) 
 
     logs = db.relationship('HabitLog', backref='habit', lazy=True, cascade='all, delete-orphan')
+    pauses = db.relationship('HabitPause', backref='habit', lazy=True, cascade='all, delete-orphan')

--- a/backend/app/models/habit_pause.py
+++ b/backend/app/models/habit_pause.py
@@ -1,0 +1,11 @@
+from app.extensions import db
+
+
+class HabitPause(db.Model):
+    __tablename__ = "habit_pauses"
+    id = db.Column(db.Integer, primary_key=True)
+    habit_id = db.Column(
+        db.Integer, db.ForeignKey("habit.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    start_date = db.Column(db.Date, nullable=False)
+    end_date = db.Column(db.Date, nullable=True)

--- a/backend/app/routes/habits.py
+++ b/backend/app/routes/habits.py
@@ -199,6 +199,7 @@ def list_habits():
             selected_date = date.fromisoformat(date_str)
         except ValueError:
             return {"error": "Invalid date format. Use YYYY-MM-DD"}, 400
+
         def active(h):
             for p in h.pauses:
                 if p.start_date <= selected_date and (
@@ -206,10 +207,23 @@ def list_habits():
                 ):
                     return False
             return h.start_date <= selected_date
+
         habits = [h for h in habits if active(h)]
 
     return jsonify([
-        {"id": h.id, "name": h.name, "start_date": h.start_date.isoformat()} for h in habits
+        {
+            "id": h.id,
+            "name": h.name,
+            "start_date": h.start_date.isoformat(),
+            "pauses": [
+                {
+                    "start_date": p.start_date.isoformat(),
+                    "end_date": p.end_date.isoformat() if p.end_date else None,
+                }
+                for p in h.pauses
+            ],
+        }
+        for h in habits
     ])
 
 

--- a/backend/migrations/versions/ea866b1fa0d9_add_habit_pause_table_and_unique_name.py
+++ b/backend/migrations/versions/ea866b1fa0d9_add_habit_pause_table_and_unique_name.py
@@ -1,0 +1,36 @@
+"""add habit pause table and unique name index
+
+Revision ID: ea866b1fa0d9
+Revises: c43a28efbed5
+Create Date: 2025-07-10 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'ea866b1fa0d9'
+down_revision = 'c43a28efbed5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'habit_pauses',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('habit_id', sa.Integer(), nullable=False),
+        sa.Column('start_date', sa.Date(), nullable=False),
+        sa.Column('end_date', sa.Date(), nullable=True),
+        sa.ForeignKeyConstraint(['habit_id'], ['habit.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_habit_pauses_habit_id'), 'habit_pauses', ['habit_id'], unique=False)
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uniq_habit_name_per_user ON habit (user_id, lower(name))"
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS uniq_habit_name_per_user")
+    op.drop_index(op.f('ix_habit_pauses_habit_id'), table_name='habit_pauses')
+    op.drop_table('habit_pauses')

--- a/backend/migrations/versions/f71cd428c220_merge_apple_id_and_habit_pause_heads.py
+++ b/backend/migrations/versions/f71cd428c220_merge_apple_id_and_habit_pause_heads.py
@@ -1,0 +1,24 @@
+"""merge apple_id and habit_pause heads
+
+Revision ID: f71cd428c220
+Revises: d84bcff0b9e4, ea866b1fa0d9
+Create Date: 2025-08-09 14:42:43.126671
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f71cd428c220'
+down_revision = ('d84bcff0b9e4', 'ea866b1fa0d9')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -26,6 +26,10 @@ export type Habit = {
   completed?: boolean;
 };
 
+export type ArchivedHabit = Habit & {
+  pause_start_date: string;
+};
+
 export type CalendarSummary = {
   [date: string]: {
     status: "inactive" | "incomplete" | "partial" | "complete" | "future";
@@ -35,8 +39,8 @@ export type CalendarSummary = {
 };
 
 // API Calls
-export const getHabits = async (): Promise<Habit[]> => {
-  const res = await api.get("/habits");
+export const getHabits = async (date?: string): Promise<Habit[]> => {
+  const res = await api.get(date ? `/habits?date=${date}` : `/habits`);
   return res.data;
 };
 
@@ -72,6 +76,19 @@ export const logHabit = async (habitId: number, date: string) => {
 
 export const undoHabit = async (habitId: number, date: string) => {
   await api.post(`/habits/${habitId}/unlog`, { date });
+};
+
+export const archiveHabit = async (habitId: number) => {
+  await api.post(`/habits/${habitId}/archive`);
+};
+
+export const unarchiveHabit = async (habitId: number) => {
+  await api.post(`/habits/${habitId}/unarchive`);
+};
+
+export const getArchivedHabits = async (): Promise<ArchivedHabit[]> => {
+  const res = await api.get(`/habits/archived`);
+  return res.data;
 };
 
 export const editHabit = async (id: number, name: string) => {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -19,11 +19,17 @@ api.interceptors.request.use(
 );
 
 // Types
+export type HabitPause = {
+  start_date: string;
+  end_date: string | null;
+};
+
 export type Habit = {
   id: number;
   name: string;
   start_date: string;
   completed?: boolean;
+  pauses?: HabitPause[];
 };
 
 export type ArchivedHabit = Habit & {

--- a/frontend/src/components/ArchivedHabitItem.tsx
+++ b/frontend/src/components/ArchivedHabitItem.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { View, Text, StyleSheet, Pressable } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { ArchivedHabit } from "../../lib/api";
+
+type Props = {
+  item: ArchivedHabit;
+  onShowMenu: () => void;
+};
+
+export default function ArchivedHabitItem({ item, onShowMenu }: Props) {
+  return (
+    <View style={styles.habit}>
+      <Text style={styles.habitText}>{item.name}</Text>
+      <Pressable onPress={onShowMenu}>
+        <Ionicons name="ellipsis-vertical" size={20} color="#000" />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  habit: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: 18,
+    borderRadius: 12,
+    backgroundColor: "#f7ce46",
+    marginBottom: 14,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  habitText: {
+    fontSize: 17,
+    fontWeight: "700",
+    color: "#000",
+    flexShrink: 1,
+    flexGrow: 1,
+    maxWidth: "85%",
+  },
+});

--- a/frontend/src/components/GridCell.tsx
+++ b/frontend/src/components/GridCell.tsx
@@ -5,14 +5,17 @@ import { StyleSheet, View } from "react-native";
 type Props = {
   completed: boolean;
   inactive: boolean;
+  paused: boolean;
   size: number;
 };
 
-export default function GridCell({ completed, inactive, size }: Props) {
+export default function GridCell({ completed, inactive, paused, size }: Props) {
   let bgColor = "#eee";
 
   if (inactive) {
     bgColor = "#e5e5e5";
+  } else if (paused) {
+    bgColor = "#909090";
   } else if (completed) {
     bgColor = "#52c41a";
   } else {

--- a/frontend/src/components/HabitMenu.tsx
+++ b/frontend/src/components/HabitMenu.tsx
@@ -5,24 +5,29 @@ import PrimaryButton from "./PrimaryButton";
 
 type HabitMenuProps = {
   onClose: () => void;
-  onEdit: () => void;
+  onEdit?: () => void;
+  onArchive?: () => void;
+  onUnarchive?: () => void;
   onDelete: () => void;
-  onArchive: () => void;
   deleting: boolean;
 };
 
 export default function HabitMenu({
   onClose,
   onEdit,
-  onDelete,
   onArchive,
+  onUnarchive,
+  onDelete,
   deleting,
 }: HabitMenuProps) {
   return (
     <Pressable style={styles.overlay} onPress={onClose}>
       <Pressable style={styles.menuBox}>
-        <PrimaryButton title="Edit Habit" onPress={onEdit} />
-        <PrimaryButton title="Archive Habit" onPress={onArchive} />
+        {onEdit && <PrimaryButton title="Edit Habit" onPress={onEdit} />}
+        {onArchive && <PrimaryButton title="Archive Habit" onPress={onArchive} />}
+        {onUnarchive && (
+          <PrimaryButton title="Unarchive Habit" onPress={onUnarchive} />
+        )}
         <PrimaryButton
           title="Delete Habit"
           onPress={onDelete}

--- a/frontend/src/components/HabitMenu.tsx
+++ b/frontend/src/components/HabitMenu.tsx
@@ -7,6 +7,7 @@ type HabitMenuProps = {
   onClose: () => void;
   onEdit: () => void;
   onDelete: () => void;
+  onArchive: () => void;
   deleting: boolean;
 };
 
@@ -14,12 +15,14 @@ export default function HabitMenu({
   onClose,
   onEdit,
   onDelete,
+  onArchive,
   deleting,
 }: HabitMenuProps) {
   return (
     <Pressable style={styles.overlay} onPress={onClose}>
       <Pressable style={styles.menuBox}>
         <PrimaryButton title="Edit Habit" onPress={onEdit} />
+        <PrimaryButton title="Archive Habit" onPress={onArchive} />
         <PrimaryButton
           title="Delete Habit"
           onPress={onDelete}

--- a/frontend/src/components/WeeklyGrid.tsx
+++ b/frontend/src/components/WeeklyGrid.tsx
@@ -97,20 +97,25 @@ export default function WeeklyGrid({
                       const completed = completedLogs[iso]?.has(habit.id);
                       const paused = habit.pauses?.some((p) => {
                         const pauseStart = parseISO(p.start_date);
-                        const pauseEnd = p.end_date ? parseISO(p.end_date) : null;
+                        const pauseEnd = p.end_date
+                          ? parseISO(p.end_date)
+                          : null;
                         const startsBeforeOrOn =
                           isBefore(pauseStart, day) || isEqual(pauseStart, day);
                         const endsAfterOrOn =
-                          !pauseEnd || isAfter(pauseEnd, day) || isEqual(pauseEnd, day);
+                          !pauseEnd ||
+                          isAfter(pauseEnd, day) ||
+                          isEqual(pauseEnd, day);
                         return startsBeforeOrOn && endsAfterOrOn;
                       });
-                      const inactive = isFuture || !started || paused;
+                      const inactive = isFuture || !started;
 
                       return (
                         <GridCell
                           key={`${habit.id}-${iso}`}
                           completed={!!completed}
-                          inactive={inactive}
+                          inactive={!!inactive}
+                          paused={!!paused}
                           size={cellSize}
                         />
                       );

--- a/frontend/src/components/WeeklyGrid.tsx
+++ b/frontend/src/components/WeeklyGrid.tsx
@@ -95,7 +95,16 @@ export default function WeeklyGrid({
                       const started =
                         isBefore(habitStart, day) || isEqual(habitStart, day);
                       const completed = completedLogs[iso]?.has(habit.id);
-                      const inactive = isFuture || !started;
+                      const paused = habit.pauses?.some((p) => {
+                        const pauseStart = parseISO(p.start_date);
+                        const pauseEnd = p.end_date ? parseISO(p.end_date) : null;
+                        const startsBeforeOrOn =
+                          isBefore(pauseStart, day) || isEqual(pauseStart, day);
+                        const endsAfterOrOn =
+                          !pauseEnd || isAfter(pauseEnd, day) || isEqual(pauseEnd, day);
+                        return startsBeforeOrOn && endsAfterOrOn;
+                      });
+                      const inactive = isFuture || !started || paused;
 
                       return (
                         <GridCell

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -12,6 +12,7 @@ import EditHabitScreen from "../screens/EditHabitScreen";
 import ForgotPasswordScreen from "../screens/ForgotPasswordScreen";
 import ResetPasswordScreen from "../screens/ResetPasswordScreen";
 import NotificationSettingsScreen from "../screens/NotificationSettingsScreen";
+import ArchivedHabitsScreen from "../screens/ArchivedHabitsScreen";
 import * as Linking from "expo-linking";
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -47,6 +48,11 @@ export default function AppNavigator() {
             <Stack.Screen
               name="NotificationSettings"
               component={NotificationSettingsScreen}
+              options={{ presentation: "modal" }}
+            />
+            <Stack.Screen
+              name="ArchivedHabits"
+              component={ArchivedHabitsScreen}
               options={{ presentation: "modal" }}
             />
           </>

--- a/frontend/src/screens/ArchivedHabitsScreen.tsx
+++ b/frontend/src/screens/ArchivedHabitsScreen.tsx
@@ -1,0 +1,103 @@
+import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import React, { useCallback, useState } from "react";
+import { View, Text, StyleSheet, ScrollView, Pressable } from "react-native";
+import { ArchivedHabit, getArchivedHabits, unarchiveHabit, deleteHabit } from "../../lib/api";
+import LoadingSpinner from "../components/LoadingSpinner";
+import PrimaryButton from "../components/PrimaryButton";
+
+export default function ArchivedHabitsScreen() {
+  const [habits, setHabits] = useState<ArchivedHabit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const navigation = useNavigation();
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const data = await getArchivedHabits();
+      setHabits(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [])
+  );
+
+  const handleUnarchive = async (id: number) => {
+    await unarchiveHabit(id);
+    load();
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteHabit(id);
+    load();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Archived habits</Text>
+      {loading ? (
+        <LoadingSpinner size="large" />
+      ) : habits.length === 0 ? (
+        <Text style={styles.empty}>No archived habits</Text>
+      ) : (
+        <ScrollView>
+          {habits.map((h) => (
+            <View key={h.id} style={styles.item}>
+              <Text style={styles.name}>{h.name}</Text>
+              <View style={styles.actions}>
+                <Pressable onPress={() => handleUnarchive(h.id)}>
+                  <Text style={styles.actionText}>Unarchive</Text>
+                </Pressable>
+                <Pressable onPress={() => handleDelete(h.id)} style={{ marginLeft: 12 }}>
+                  <Text style={[styles.actionText, { color: "red" }]}>Delete</Text>
+                </Pressable>
+              </View>
+            </View>
+          ))}
+        </ScrollView>
+      )}
+      <PrimaryButton title="Close" onPress={() => navigation.goBack()} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: "#fff",
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "700",
+    marginBottom: 20,
+    textAlign: "center",
+  },
+  empty: {
+    textAlign: "center",
+    marginTop: 20,
+    color: "#555",
+  },
+  item: {
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderColor: "#eee",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  name: {
+    fontSize: 18,
+  },
+  actions: {
+    flexDirection: "row",
+  },
+  actionText: {
+    fontSize: 14,
+    color: "blue",
+  },
+});

--- a/frontend/src/screens/CreateHabitScreen.tsx
+++ b/frontend/src/screens/CreateHabitScreen.tsx
@@ -1,8 +1,8 @@
 import { useNavigation } from "@react-navigation/native";
 import { format } from "date-fns";
 import React, { useState } from "react";
-import { StyleSheet, Text, TextInput, View } from "react-native";
-import api from "../../lib/api";
+import { Alert, StyleSheet, Text, TextInput, View } from "react-native";
+import api, { unarchiveHabit } from "../../lib/api";
 import PrimaryButton from "../components/PrimaryButton";
 import { isValidHabit } from "../utils/validation";
 import { AxiosError } from "axios";
@@ -33,9 +33,35 @@ export default function CreateHabitScreen() {
       setError(null);
       navigation.goBack();
     } catch (err) {
-      const error = err as AxiosError<{ error?: string }>;
-      const errorMsg = error?.response?.data?.error || "Please try again later";
-      setError(errorMsg);
+      const error = err as AxiosError<any>;
+      if (error.response?.status === 409) {
+        const data = error.response.data;
+        if (data.error === "duplicate_name_archived") {
+          Alert.alert(
+            `Habit exists`,
+            `You already have an archived habit named '${name.trim()}'. Unarchive it instead, or choose a different name.`,
+            [
+              {
+                text: "Unarchive",
+                onPress: async () => {
+                  await unarchiveHabit(data.archivedHabitId);
+                  navigation.goBack();
+                },
+              },
+              { text: "Choose different name", style: "cancel" },
+            ]
+          );
+        } else if (data.error === "duplicate_name_active") {
+          setError(
+            `You already have an active habit named '${name.trim()}'. Choose a different name.`
+          );
+        } else {
+          setError(data.error || "Please try again later");
+        }
+      } else {
+        const errorMsg = error?.response?.data?.error || "Please try again later";
+        setError(errorMsg);
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -20,6 +20,7 @@ import {
   getHabitSummary,
   logHabit,
   undoHabit,
+  archiveHabit,
 } from "../../lib/api";
 import { RootStackParamList } from "../../types";
 import HabitItem from "../components/HabitItem";
@@ -134,6 +135,33 @@ export default function Home() {
     );
   };
 
+  const handleArchiveHabit = (habitId: number) => {
+    Alert.alert(
+      "Archive habit?",
+      "It will be hidden from your Home screen for future dates. Past progress stays visible. You can unarchive it anytime.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Archive",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              await archiveHabit(habitId);
+              setShowHabitMenu(null);
+              loadHabits(true);
+            } catch (err: any) {
+              Toast.show({
+                type: "error",
+                text1: "Error archiving habit",
+                text2: err.response?.data?.error || "Server unreachable.",
+              });
+            }
+          },
+        },
+      ]
+    );
+  };
+
   return (
     <>
       <HeaderNav
@@ -150,9 +178,17 @@ export default function Home() {
           }
         >
           <View style={styles.innerContainer}>
-            <Text style={styles.objectivesTitle}>
-              {format(date, "EEEE")} Habits
-            </Text>
+            <View style={styles.titleRow}>
+              <Text style={styles.objectivesTitle}>
+                {format(date, "EEEE")} Habits
+              </Text>
+              <Pressable
+                onPress={() => navigation.navigate("ArchivedHabits")}
+                hitSlop={10}
+              >
+                <Ionicons name="archive-outline" size={24} color="#000" />
+              </Pressable>
+            </View>
 
             {loading ? (
               <LoadingSpinner size="large" />
@@ -209,6 +245,7 @@ export default function Home() {
             });
           }}
           onDelete={() => handleDeleteHabit(showHabitMenu)}
+          onArchive={() => handleArchiveHabit(showHabitMenu)}
           deleting={deletingId === showHabitMenu}
         />
       )}
@@ -226,14 +263,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     minHeight: "100%",
   },
+  titleRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: 20,
+    marginBottom: 16,
+    backgroundColor: "#fff",
+  },
   objectivesTitle: {
     fontSize: 24,
     fontWeight: "700",
-    marginBottom: 16,
-    marginTop: 20,
     color: "#000",
-    textAlign: "center",
-    backgroundColor: "#fff",
   },
   fab: {
     position: "absolute",

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -8,6 +8,7 @@ export type RootStackParamList = {
   ForgotPassword: undefined;
   ResetPassword: { token: string };
   NotificationSettings: undefined;
+  ArchivedHabits: undefined;
 };
 
 export type TabParamList = {


### PR DESCRIPTION
## Summary
- track habit pause periods with new HabitPause model and unique name constraint
- implement archive/unarchive APIs and archived list endpoint with date-based filtering
- add frontend archived habit flow and archive button on home screen

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689745942b8c8330b1c10febcc9e433e