### PR TITLE
feat: add habit-specific reminders

### DIFF
--- a/frontend/lib/habitReminders.ts
+++ b/frontend/lib/habitReminders.ts
@@ -1,0 +1,95 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Notifications from "expo-notifications";
+import { SchedulableTriggerInputTypes } from "expo-notifications";
+
+const TIME_KEY_PREFIX = "habitReminderTime:";
+const NOTIF_KEY_PREFIX = "habitReminderNotificationId:";
+
+function getTimeKey(habitId: number): string {
+  return `${TIME_KEY_PREFIX}${habitId}`;
+}
+
+function getNotificationKey(habitId: number): string {
+  return `${NOTIF_KEY_PREFIX}${habitId}`;
+}
+
+export type ReminderTime = {
+  hour: number;
+  minute: number;
+};
+
+export async function getHabitReminderTime(
+  habitId: number
+): Promise<ReminderTime | null> {
+  const stored = await AsyncStorage.getItem(getTimeKey(habitId));
+  return stored ? (JSON.parse(stored) as ReminderTime) : null;
+}
+
+async function scheduleNotification(
+  habitId: number,
+  habitName: string,
+  time: ReminderTime
+): Promise<boolean> {
+  let { status } = await Notifications.getPermissionsAsync();
+  if (status !== "granted") {
+    const result = await Notifications.requestPermissionsAsync();
+    status = result.status;
+  }
+  if (status !== "granted") {
+    return false;
+  }
+
+  const existing = await AsyncStorage.getItem(getNotificationKey(habitId));
+  if (existing) {
+    try {
+      await Notifications.cancelScheduledNotificationAsync(existing);
+    } catch {
+      // ignore
+    }
+  }
+
+  const trigger: Notifications.CalendarTriggerInput = {
+    hour: time.hour,
+    minute: time.minute,
+    repeats: true,
+    type: SchedulableTriggerInputTypes.CALENDAR,
+  };
+
+  const id = await Notifications.scheduleNotificationAsync({
+    content: {
+      title: habitName,
+      body: "Time for your habit",
+    },
+    trigger,
+  });
+
+  await AsyncStorage.setItem(getNotificationKey(habitId), id);
+  return true;
+}
+
+export async function saveHabitReminder(
+  habitId: number,
+  habitName: string,
+  time: ReminderTime
+): Promise<boolean> {
+  await AsyncStorage.setItem(getTimeKey(habitId), JSON.stringify(time));
+  const scheduled = await scheduleNotification(habitId, habitName, time);
+  return scheduled;
+}
+
+export async function cancelHabitReminder(habitId: number): Promise<void> {
+  const id = await AsyncStorage.getItem(getNotificationKey(habitId));
+  if (id) {
+    try {
+      await Notifications.cancelScheduledNotificationAsync(id);
+    } catch {
+      // ignore
+    }
+    await AsyncStorage.removeItem(getNotificationKey(habitId));
+  }
+}
+
+export async function removeHabitReminder(habitId: number): Promise<void> {
+  await cancelHabitReminder(habitId);
+  await AsyncStorage.removeItem(getTimeKey(habitId));
+}

--- a/frontend/src/components/HabitMenu.tsx
+++ b/frontend/src/components/HabitMenu.tsx
@@ -1,7 +1,8 @@
 // frontend/src/components/HabitMenu.tsx
-import React from "react";
-import { Pressable, StyleSheet, View } from "react-native";
+import React, { useEffect, useState } from "react";
+import { Pressable, StyleSheet, View, Text } from "react-native";
 import PrimaryButton from "./PrimaryButton";
+import { getHabitReminderTime } from "../../lib/habitReminders";
 
 type HabitMenuProps = {
   onClose: () => void;
@@ -10,6 +11,8 @@ type HabitMenuProps = {
   onUnarchive?: () => void;
   onDelete: () => void;
   deleting: boolean;
+  habitId?: number;
+  onReminder?: () => void;
 };
 
 export default function HabitMenu({
@@ -19,7 +22,26 @@ export default function HabitMenu({
   onUnarchive,
   onDelete,
   deleting,
+  habitId,
+  onReminder,
 }: HabitMenuProps) {
+  const [subtitle, setSubtitle] = useState<string>("Off");
+
+  useEffect(() => {
+    if (habitId === undefined) return;
+    const load = async () => {
+      const time = await getHabitReminderTime(habitId);
+      if (time) {
+        const h = time.hour.toString().padStart(2, "0");
+        const m = time.minute.toString().padStart(2, "0");
+        setSubtitle(`${h}:${m}`);
+      } else {
+        setSubtitle("Off");
+      }
+    };
+    load();
+  }, [habitId]);
+
   return (
     <Pressable style={styles.overlay} onPress={onClose}>
       <Pressable style={styles.menuBox}>
@@ -27,6 +49,12 @@ export default function HabitMenu({
         {onArchive && <PrimaryButton title="Archive Habit" onPress={onArchive} />}
         {onUnarchive && (
           <PrimaryButton title="Unarchive Habit" onPress={onUnarchive} />
+        )}
+        {habitId !== undefined && onReminder && (
+          <Pressable style={styles.reminderButton} onPress={onReminder}>
+            <Text style={styles.reminderTitle}>Custom Reminder</Text>
+            <Text style={styles.reminderSubtitle}>{subtitle}</Text>
+          </Pressable>
         )}
         <PrimaryButton
           title="Delete Habit"
@@ -62,5 +90,23 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     width: 300,
     elevation: 5,
+  },
+  reminderButton: {
+    backgroundColor: "#fff",
+    paddingVertical: 14,
+    paddingHorizontal: 28,
+    borderRadius: 12,
+    marginVertical: 6,
+    borderWidth: 1,
+    borderColor: "#e0e0e0",
+  },
+  reminderTitle: {
+    color: "#000",
+    fontWeight: "700",
+    fontSize: 16,
+  },
+  reminderSubtitle: {
+    color: "#555",
+    fontSize: 14,
   },
 });

--- a/frontend/src/components/HabitReminderModal.tsx
+++ b/frontend/src/components/HabitReminderModal.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from "react";
+import { Pressable, StyleSheet, Text, Platform } from "react-native";
+import DateTimePicker from "@react-native-community/datetimepicker";
+import Toast from "react-native-toast-message";
+import PrimaryButton from "./PrimaryButton";
+import {
+  getHabitReminderTime,
+  saveHabitReminder,
+  removeHabitReminder,
+  ReminderTime,
+} from "../../lib/habitReminders";
+
+type Props = {
+  habitId: number;
+  habitName: string;
+  onClose: () => void;
+};
+
+export default function HabitReminderModal({ habitId, habitName, onClose }: Props) {
+  const [time, setTime] = useState<Date>(new Date());
+  const [hasReminder, setHasReminder] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const stored = await getHabitReminderTime(habitId);
+      if (stored) {
+        const d = new Date();
+        d.setHours(stored.hour);
+        d.setMinutes(stored.minute);
+        d.setSeconds(0);
+        setTime(d);
+        setHasReminder(true);
+      }
+    };
+    load();
+  }, [habitId]);
+
+  const handleSave = async () => {
+    const reminder: ReminderTime = {
+      hour: time.getHours(),
+      minute: time.getMinutes(),
+    };
+    const granted = await saveHabitReminder(habitId, habitName, reminder);
+    if (!granted) {
+      Toast.show({
+        type: "info",
+        text1:
+          "Notifications are disabled. Enable in Settings to receive reminders.",
+      });
+    }
+    onClose();
+  };
+
+  const handleRemove = async () => {
+    await removeHabitReminder(habitId);
+    onClose();
+  };
+
+  return (
+    <Pressable style={styles.overlay} onPress={onClose}>
+      <Pressable style={styles.box} onPress={() => {}}>
+        <Text style={styles.title}>Custom Reminder</Text>
+        <DateTimePicker
+          value={time}
+          mode="time"
+          is24Hour={true}
+          display={Platform.OS === "ios" ? "spinner" : "default"}
+          onChange={(_, selected) => {
+            if (selected) setTime(selected);
+          }}
+        />
+        <PrimaryButton title="Save" onPress={handleSave} />
+        {hasReminder && (
+          <PrimaryButton
+            title="Remove"
+            onPress={handleRemove}
+            style={styles.removeButton}
+            textStyle={{ color: "red" }}
+          />
+        )}
+      </Pressable>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "rgba(0,0,0,0.3)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  box: {
+    backgroundColor: "#fff",
+    padding: 24,
+    borderRadius: 16,
+    width: 300,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  removeButton: {
+    backgroundColor: "#fff",
+    borderWidth: 1,
+    borderColor: "#e0e0e0",
+  },
+});

--- a/frontend/src/screens/ArchivedHabitsScreen.tsx
+++ b/frontend/src/screens/ArchivedHabitsScreen.tsx
@@ -12,6 +12,7 @@ import LoadingSpinner from "../components/LoadingSpinner";
 import PrimaryButton from "../components/PrimaryButton";
 import ArchivedHabitItem from "../components/ArchivedHabitItem";
 import HabitMenu from "../components/HabitMenu";
+import { removeHabitReminder } from "../../lib/habitReminders";
 
 export default function ArchivedHabitsScreen() {
   const [habits, setHabits] = useState<ArchivedHabit[]>([]);
@@ -63,6 +64,7 @@ export default function ArchivedHabitsScreen() {
             setDeletingId(id);
             try {
               await deleteHabit(id);
+              await removeHabitReminder(id);
               setShowHabitMenu(null);
               load();
             } catch (err: any) {

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -29,6 +29,11 @@ import HeaderNav from "../components/HeaderNav";
 import LoadingSpinner from "../components/LoadingSpinner";
 import PrimaryButton from "../components/PrimaryButton";
 import SwipeableDayView from "../components/SwipeableView";
+import HabitReminderModal from "../components/HabitReminderModal";
+import {
+  cancelHabitReminder,
+  removeHabitReminder,
+} from "../../lib/habitReminders";
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, "Main">;
 
@@ -37,6 +42,7 @@ export default function Home() {
   const [habits, setHabits] = useState<Habit[]>([]);
   const [refreshing, setRefreshing] = useState(false);
   const [showHabitMenu, setShowHabitMenu] = useState<number | null>(null);
+  const [reminderHabit, setReminderHabit] = useState<Habit | null>(null);
   const [loading, setLoading] = useState(false);
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [error, setError] = useState(false);
@@ -118,6 +124,7 @@ export default function Home() {
             setDeletingId(habitId);
             try {
               await deleteHabit(habitId);
+              await removeHabitReminder(habitId);
               setHabits((prev) => prev.filter((h) => h.id !== habitId));
               setShowHabitMenu(null);
             } catch (err: any) {
@@ -147,6 +154,7 @@ export default function Home() {
           onPress: async () => {
             try {
               await archiveHabit(habitId);
+              await cancelHabitReminder(habitId);
               setShowHabitMenu(null);
               loadHabits(true);
             } catch (err: any) {
@@ -246,7 +254,21 @@ export default function Home() {
           }}
           onDelete={() => handleDeleteHabit(showHabitMenu)}
           onArchive={() => handleArchiveHabit(showHabitMenu)}
+          habitId={showHabitMenu}
+          onReminder={() => {
+            const habit = habits.find((h) => h.id === showHabitMenu);
+            if (!habit) return;
+            setShowHabitMenu(null);
+            setReminderHabit(habit);
+          }}
           deleting={deletingId === showHabitMenu}
+        />
+      )}
+      {reminderHabit && (
+        <HabitReminderModal
+          habitId={reminderHabit.id}
+          habitName={reminderHabit.name}
+          onClose={() => setReminderHabit(null)}
         />
       )}
     </>


### PR DESCRIPTION
## Summary
- allow per-habit custom reminders stored in AsyncStorage and scheduled with Expo Notifications
- show reminder status in habit menu and provide modal to set or remove reminders
- cancel or remove scheduled reminders when archiving or deleting habits

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689a297721948330995c199ce480144d