### PR TITLE
feat: add onboarding tooltip to HomeScreen

### DIFF
--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -11,26 +11,28 @@ export default function InfoTooltip({ onClose }: InfoTooltipProps) {
     <Pressable style={styles.overlay} onPress={onClose}>
       <Pressable style={styles.box} onPress={() => {}}>
         <Text style={styles.title}>How the app works</Text>
+
         <Text style={styles.text}>
-          1) create some habits that you'd like to do every day, e.g., take
-          supplements, or walk 10k steps, or stretch
+          1) Create daily habits you want to track - for example: take
+          supplements, walk 10k steps, or stretch.
         </Text>
+
         <Text style={styles.text}>
-          2) set a reminder on the notifications time to get a daily reminder to
-          log habits, or edit a specific habit to get a custom reminder for that
-          habit
+          2) Set reminders to help you stay consistent. You can choose a daily
+          notification time or add custom reminders for individual habits.
         </Text>
+
         <Text style={styles.text}>
-          3) when a habit is complete, tap it to mark it as done. This will
-          provide a satisfying check mark for a nice dopamine release
+          3) When you complete a habit, tap it to mark it as done. Enjoy the
+          satisfying check mark - and a little hit of dopamine.
         </Text>
+
         <Text style={styles.text}>
-          4) over time, progress will be stored and visualised into different
-          formats to see the progress you've made. The calendar screen will show
-          if you've completed all, some, or none of your habits on each day in a
-          month. The grid screen will show a more detailed break down, showing
-          the track record of each habit throughout the month.
+          4) Watch your progress build over time. The calendar view shows
+          whether you’ve completed all, some, or none of your habits each day.
+          The grid view breaks it down habit-by-habit across the month.
         </Text>
+
         <PrimaryButton title="Got it" onPress={onClose} />
       </Pressable>
     </Pressable>
@@ -67,4 +69,3 @@ const styles = StyleSheet.create({
     color: "#333",
   },
 });
-

--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Pressable, StyleSheet, Text } from "react-native";
+import PrimaryButton from "./PrimaryButton";
+
+interface InfoTooltipProps {
+  onClose: () => void;
+}
+
+export default function InfoTooltip({ onClose }: InfoTooltipProps) {
+  return (
+    <Pressable style={styles.overlay} onPress={onClose}>
+      <Pressable style={styles.box} onPress={() => {}}>
+        <Text style={styles.title}>How the app works</Text>
+        <Text style={styles.text}>
+          1) create some habits that you'd like to do every day, e.g., take
+          supplements, or walk 10k steps, or stretch
+        </Text>
+        <Text style={styles.text}>
+          2) set a reminder on the notifications time to get a daily reminder to
+          log habits, or edit a specific habit to get a custom reminder for that
+          habit
+        </Text>
+        <Text style={styles.text}>
+          3) when a habit is complete, tap it to mark it as done. This will
+          provide a satisfying check mark for a nice dopamine release
+        </Text>
+        <Text style={styles.text}>
+          4) over time, progress will be stored and visualised into different
+          formats to see the progress you've made. The calendar screen will show
+          if you've completed all, some, or none of your habits on each day in a
+          month. The grid screen will show a more detailed break down, showing
+          the track record of each habit throughout the month.
+        </Text>
+        <PrimaryButton title="Got it" onPress={onClose} />
+      </Pressable>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "rgba(0,0,0,0.3)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  box: {
+    backgroundColor: "#fff",
+    padding: 24,
+    borderRadius: 16,
+    width: 300,
+    gap: 12,
+    elevation: 5,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#000",
+    textAlign: "center",
+  },
+  text: {
+    fontSize: 16,
+    color: "#333",
+  },
+});
+

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -209,18 +209,14 @@ export default function Home() {
                 {format(date, "EEEE")} Habits
               </Text>
               <View style={styles.iconRow}>
+                <Pressable onPress={() => setShowInfo(true)} hitSlop={10}>
+                  <Ionicons name="help-circle-outline" size={28} color="#000" />
+                </Pressable>
                 <Pressable
                   onPress={() => navigation.navigate("ArchivedHabits")}
                   hitSlop={10}
                 >
                   <Ionicons name="archive-outline" size={24} color="#000" />
-                </Pressable>
-                <Pressable onPress={() => setShowInfo(true)} hitSlop={10}>
-                  <Ionicons
-                    name="help-circle-outline"
-                    size={24}
-                    color="#000"
-                  />
                 </Pressable>
               </View>
             </View>
@@ -324,7 +320,7 @@ const styles = StyleSheet.create({
   iconRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 16,
+    gap: 12,
   },
   objectivesTitle: {
     fontSize: 24,


### PR DESCRIPTION
## Summary
- add InfoTooltip modal describing how to use the app
- show tooltip on first launch and via new help icon on Home screen

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689a53af681c8330a95d121982ce87d4