### PR TITLE
feat: show day details on calendar

### DIFF
--- a/frontend/src/components/CalendarGrid.tsx
+++ b/frontend/src/components/CalendarGrid.tsx
@@ -6,17 +6,18 @@ import {
   startOfMonth,
 } from "date-fns";
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { CalendarSummary } from "../../lib/api";
 
 type Props = {
   month: Date;
   summary: CalendarSummary;
+  onDayPress?: (day: Date) => void;
 };
 
 const dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-export default function CalendarGrid({ month, summary }: Props) {
+export default function CalendarGrid({ month, summary, onDayPress }: Props) {
   const monthStart = startOfMonth(month);
   const monthEnd = endOfMonth(month);
   const allDays = eachDayOfInterval({ start: monthStart, end: monthEnd });
@@ -70,12 +71,13 @@ export default function CalendarGrid({ month, summary }: Props) {
             }[status ?? "inactive"];
 
             return (
-              <View
+              <TouchableOpacity
                 key={iso}
                 style={[styles.cell, { backgroundColor: bgColor }]}
+                onPress={() => onDayPress?.(day)}
               >
                 <Text style={styles.dayText}>{day.getDate()}</Text>
-              </View>
+              </TouchableOpacity>
             );
           })}
         </View>

--- a/frontend/src/screens/CalendarScreen.tsx
+++ b/frontend/src/screens/CalendarScreen.tsx
@@ -1,6 +1,6 @@
 import { addMonths, format, subMonths } from "date-fns";
 import React, { useEffect, useState } from "react";
-import { RefreshControl, ScrollView, StyleSheet, View } from "react-native";
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from "react-native";
 import { CalendarSummary, getCalendarSummary } from "../../lib/api";
 import CalendarGrid from "../components/CalendarGrid";
 import HeaderNav from "../components/HeaderNav";
@@ -11,6 +11,7 @@ import Toast from "react-native-toast-message";
 export default function CalendarScreen() {
   const [selectedMonth, setSelectedMonth] = useState(new Date());
   const [calendarData, setCalendarData] = useState<CalendarSummary>({});
+  const [selectedDay, setSelectedDay] = useState<Date | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -66,7 +67,31 @@ export default function CalendarScreen() {
           <LoadingSpinner />
         ) : (
           <>
-            <CalendarGrid month={selectedMonth} summary={calendarData} />
+            <CalendarGrid
+              month={selectedMonth}
+              summary={calendarData}
+              onDayPress={setSelectedDay}
+            />
+            {selectedDay && (
+              <View style={styles.dayInfo}>
+                <Text style={styles.dayInfoDate}>
+                  {format(selectedDay, "MMMM d, yyyy")}
+                </Text>
+                <Text style={styles.dayInfoText}>
+                  Status: {
+                    calendarData[format(selectedDay, "yyyy-MM-dd")]?.status ||
+                    "inactive"
+                  }
+                </Text>
+                <Text style={styles.dayInfoText}>
+                  {`Habits completed: ${
+                    calendarData[format(selectedDay, "yyyy-MM-dd")]?.completed ?? 0
+                  }/${
+                    calendarData[format(selectedDay, "yyyy-MM-dd")]?.total ?? 0
+                  }`}
+                </Text>
+              </View>
+            )}
             <Legend />
           </>
         )}
@@ -81,5 +106,16 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     paddingBottom: 100,
     backgroundColor: "#fff",
+  },
+  dayInfo: {
+    marginTop: 20,
+    alignItems: "center",
+  },
+  dayInfoDate: {
+    fontWeight: "700",
+    marginBottom: 4,
+  },
+  dayInfoText: {
+    fontSize: 14,
   },
 });


### PR DESCRIPTION
## Summary
- show date info under calendar grid when user selects a day
- make calendar cells pressable and send selected date back to screen

## Testing
- `npx tsc --noEmit`
- `npm test` (fails: Missing script: "test")
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba81932f08330bcd70d86c590baee