### PR TITLE
Fix Android reminder handling and back navigation

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -31,7 +31,9 @@
         "foregroundImage": "./assets/icon.png",
         "backgroundColor": "#f7ce46"
       },
-      "edgeToEdgeEnabled": true
+      "edgeToEdgeEnabled": true,
+      "permissions": ["POST_NOTIFICATIONS"],
+      "useNextNotificationsApi": true
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/frontend/src/components/HabitReminderModal.tsx
+++ b/frontend/src/components/HabitReminderModal.tsx
@@ -85,7 +85,7 @@ export default function HabitReminderModal({ habit, onClose }: Props) {
           value={time}
           mode="time"
           is24Hour={true}
-          display={Platform.OS === "ios" ? "spinner" : "default"}
+          display={"spinner"}
           onChange={async (_, selected) => {
             if (selected) {
               setTime(selected);

--- a/frontend/src/components/HabitReminderModal.tsx
+++ b/frontend/src/components/HabitReminderModal.tsx
@@ -35,9 +35,10 @@ export default function HabitReminderModal({ habit, onClose }: Props) {
       }
     };
     load();
-    }, [habit.id]);
+  }, [habit.id]);
 
-  const handleSave = async () => {
+  const handleSave = async (t?: Date) => {
+    const saveTime = t || time;
     if (!hasReminder) {
       const count = await getHabitReminderCount();
       if (count >= MAX_REMINDERS) {
@@ -50,8 +51,8 @@ export default function HabitReminderModal({ habit, onClose }: Props) {
       }
     }
     const reminder: ReminderTime = {
-      hour: time.getHours(),
-      minute: time.getMinutes(),
+      hour: saveTime.getHours(),
+      minute: saveTime.getMinutes(),
     };
     const granted = await saveHabitReminder(
       habit.id,
@@ -67,6 +68,7 @@ export default function HabitReminderModal({ habit, onClose }: Props) {
           "Notifications are disabled. Enable in Settings to receive reminders.",
       });
     }
+    setHasReminder(true);
     onClose();
   };
 
@@ -83,12 +85,19 @@ export default function HabitReminderModal({ habit, onClose }: Props) {
           value={time}
           mode="time"
           is24Hour={true}
-          display="spinner"
-          onChange={(_, selected) => {
-            if (selected) setTime(selected);
+          display={Platform.OS === "ios" ? "spinner" : "default"}
+          onChange={async (_, selected) => {
+            if (selected) {
+              setTime(selected);
+              if (Platform.OS === "android") {
+                await handleSave(selected);
+              }
+            }
           }}
         />
-        <PrimaryButton title="Save" onPress={handleSave} />
+        {Platform.OS === "ios" && (
+          <PrimaryButton title="Save" onPress={() => handleSave()} />
+        )}
         {hasReminder && (
           <PrimaryButton
             title="Remove"

--- a/frontend/src/screens/CreateHabitScreen.tsx
+++ b/frontend/src/screens/CreateHabitScreen.tsx
@@ -90,12 +90,12 @@ export default function CreateHabitScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-    >
+    <KeyboardAvoidingView style={styles.container} behavior={"padding"}>
       {Platform.OS === "android" && (
-        <Pressable onPress={() => navigation.goBack()} style={styles.backButton}>
+        <Pressable
+          onPress={() => navigation.goBack()}
+          style={styles.backButton}
+        >
           <Ionicons name="arrow-back" size={24} color="#000" />
         </Pressable>
       )}
@@ -200,7 +200,7 @@ const styles = StyleSheet.create({
   },
   backButton: {
     position: "absolute",
-    top: Platform.OS === "ios" ? 60 : 30,
+    top: 50,
     left: 20,
     zIndex: 10,
   },
@@ -239,6 +239,8 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     borderWidth: 1,
     borderColor: "#ccc",
+    marginRight: 2,
+    marginBottom: 8,
   },
   chipSelected: {
     backgroundColor: "#f7ce46",
@@ -253,7 +255,8 @@ const styles = StyleSheet.create({
   },
   weekRow: {
     flexDirection: "row",
-    justifyContent: "space-between",
+    flexWrap: "wrap",
+    justifyContent: "flex-start",
     marginBottom: 16,
   },
 });

--- a/frontend/src/screens/CreateHabitScreen.tsx
+++ b/frontend/src/screens/CreateHabitScreen.tsx
@@ -15,6 +15,7 @@ import { format } from "date-fns";
 import { createHabit, unarchiveHabit } from "../../lib/api";
 import PrimaryButton from "../components/PrimaryButton";
 import { isValidHabit } from "../utils/validation";
+import { Ionicons } from "@expo/vector-icons";
 
 export default function CreateHabitScreen() {
   const navigation = useNavigation();
@@ -93,6 +94,11 @@ export default function CreateHabitScreen() {
       style={styles.container}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
+      {Platform.OS === "android" && (
+        <Pressable onPress={() => navigation.goBack()} style={styles.backButton}>
+          <Ionicons name="arrow-back" size={24} color="#000" />
+        </Pressable>
+      )}
       <View style={styles.card}>
         <Text style={styles.label}>New Habit</Text>
         <TextInput
@@ -191,6 +197,12 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     marginBottom: 10,
     color: "#000",
+  },
+  backButton: {
+    position: "absolute",
+    top: Platform.OS === "ios" ? 60 : 30,
+    left: 20,
+    zIndex: 10,
   },
   subLabel: {
     fontSize: 14,

--- a/frontend/src/screens/EditHabitScreen.tsx
+++ b/frontend/src/screens/EditHabitScreen.tsx
@@ -15,6 +15,7 @@ import { editHabit, unarchiveHabit } from "../../lib/api";
 import PrimaryButton from "../components/PrimaryButton";
 import { isValidHabit } from "../utils/validation";
 import { format } from "date-fns";
+import { Ionicons } from "@expo/vector-icons";
 
 export default function EditHabitScreen() {
   const route = useRoute<any>();
@@ -89,6 +90,11 @@ export default function EditHabitScreen() {
       style={styles.container}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
+      {Platform.OS === "android" && (
+        <Pressable onPress={() => navigation.goBack()} style={styles.backButton}>
+          <Ionicons name="arrow-back" size={24} color="#000" />
+        </Pressable>
+      )}
       <View style={styles.card}>
         <Text style={styles.label}>Edit Habit</Text>
         <TextInput
@@ -181,6 +187,12 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     marginBottom: 10,
     color: "#000",
+  },
+  backButton: {
+    position: "absolute",
+    top: Platform.OS === "ios" ? 60 : 30,
+    left: 20,
+    zIndex: 10,
   },
   subLabel: {
     fontSize: 14,

--- a/frontend/src/screens/EditHabitScreen.tsx
+++ b/frontend/src/screens/EditHabitScreen.tsx
@@ -20,8 +20,12 @@ import { Ionicons } from "@expo/vector-icons";
 export default function EditHabitScreen() {
   const route = useRoute<any>();
   const navigation = useNavigation();
-  const { habitId, currentName, frequency: currentFreq, daysOfWeek: currentDays } =
-    route.params;
+  const {
+    habitId,
+    currentName,
+    frequency: currentFreq,
+    daysOfWeek: currentDays,
+  } = route.params;
 
   const [name, setName] = useState(currentName);
   const [frequency, setFrequency] = useState<"DAILY" | "WEEKLY">(currentFreq);
@@ -86,12 +90,12 @@ export default function EditHabitScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-    >
+    <KeyboardAvoidingView style={styles.container} behavior={"padding"}>
       {Platform.OS === "android" && (
-        <Pressable onPress={() => navigation.goBack()} style={styles.backButton}>
+        <Pressable
+          onPress={() => navigation.goBack()}
+          style={styles.backButton}
+        >
           <Ionicons name="arrow-back" size={24} color="#000" />
         </Pressable>
       )}
@@ -190,7 +194,7 @@ const styles = StyleSheet.create({
   },
   backButton: {
     position: "absolute",
-    top: Platform.OS === "ios" ? 60 : 30,
+    top: 50,
     left: 20,
     zIndex: 10,
   },
@@ -229,6 +233,8 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     borderWidth: 1,
     borderColor: "#ccc",
+    marginRight: 2,
+    marginBottom: 8,
   },
   chipSelected: {
     backgroundColor: "#f7ce46",
@@ -243,7 +249,8 @@ const styles = StyleSheet.create({
   },
   weekRow: {
     flexDirection: "row",
-    justifyContent: "space-between",
+    flexWrap: "wrap",
+    justifyContent: "flex-start",
     marginBottom: 16,
   },
 });

--- a/frontend/src/screens/ForgotPasswordScreen.tsx
+++ b/frontend/src/screens/ForgotPasswordScreen.tsx
@@ -8,7 +8,7 @@ import {
   Pressable,
   StyleSheet,
   Text,
-  TextInput
+  TextInput,
 } from "react-native";
 import Toast from "react-native-toast-message";
 import api from "../../lib/api";
@@ -59,10 +59,7 @@ export default function ForgotPasswordScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-    >
+    <KeyboardAvoidingView style={styles.container} behavior={"padding"}>
       <Pressable onPress={() => navigation.goBack()} style={styles.backButton}>
         <Ionicons name="arrow-back" size={24} color="#000" />
       </Pressable>
@@ -98,7 +95,7 @@ const styles = StyleSheet.create({
   },
   backButton: {
     position: "absolute",
-    top: Platform.OS === "ios" ? 60 : 30,
+    top: 60,
     left: 20,
     zIndex: 10,
   },

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -350,10 +350,13 @@ const styles = StyleSheet.create({
   scrollContent: {
     flexGrow: 1,
     paddingBottom: 100,
+    alignItems: "center",
+    paddingHorizontal: 20,
     backgroundColor: "#fff",
   },
   innerContainer: {
-    paddingHorizontal: 20,
+    width: "100%",
+    maxWidth: 480,
     minHeight: "100%",
   },
   titleRow: {

--- a/frontend/src/screens/LoginScreen.tsx
+++ b/frontend/src/screens/LoginScreen.tsx
@@ -103,10 +103,7 @@ const LoginScreen = () => {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-    >
+    <KeyboardAvoidingView style={styles.container} behavior={"padding"}>
       <View style={styles.card}>
         <Text style={styles.title}>Habee</Text>
 

--- a/frontend/src/screens/NotificationSettingsScreen.tsx
+++ b/frontend/src/screens/NotificationSettingsScreen.tsx
@@ -69,7 +69,9 @@ export default function NotificationSettingsScreen() {
         setEditing(false);
         Alert.alert(
           "Reminder Set",
-          `You'll be reminded daily at ${hour}:${minute < 10 ? "0" : ""}${minute}`
+          `You'll be reminded daily at ${hour}:${
+            minute < 10 ? "0" : ""
+          }${minute}`
         );
       } else {
         setEditing(false);
@@ -128,7 +130,10 @@ export default function NotificationSettingsScreen() {
         }
         const habits = await getHabits();
         const habitMap = new Map(
-          habits.map((h) => [h.id, { name: h.name, frequency: h.frequency, days: h.days_of_week }])
+          habits.map((h) => [
+            h.id,
+            { name: h.name, frequency: h.frequency, days: h.days_of_week },
+          ])
         );
         const items: CustomReminder[] = [];
         for (const key of reminderKeys) {
@@ -216,7 +221,7 @@ export default function NotificationSettingsScreen() {
                 value={pendingTime || selectedTime}
                 mode="time"
                 is24Hour={false}
-                display={Platform.OS === "ios" ? "spinner" : "default"}
+                display={"spinner"}
                 onChange={handleTimeChange}
               />
 
@@ -304,9 +309,7 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 20,
   },
   backButton: {
-    position: "absolute",
-    top: Platform.OS === "ios" ? 60 : 30,
-    left: 20,
+    marginBottom: 5,
     zIndex: 10,
   },
   row: {

--- a/frontend/src/screens/RegisterScreen.tsx
+++ b/frontend/src/screens/RegisterScreen.tsx
@@ -90,10 +90,7 @@ export default function RegisterScreen({ navigation }: { navigation: any }) {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-    >
+    <KeyboardAvoidingView style={{ flex: 1 }} behavior={"padding"}>
       <ScrollView
         contentContainerStyle={styles.container}
         keyboardShouldPersistTaps="handled"

--- a/frontend/src/screens/ResetPasswordScreen.tsx
+++ b/frontend/src/screens/ResetPasswordScreen.tsx
@@ -80,10 +80,7 @@ export default function ResetPasswordScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-    >
+    <KeyboardAvoidingView style={styles.container} behavior={"padding"}>
       <Pressable onPress={() => navigation.goBack()} style={styles.backButton}>
         <Ionicons name="arrow-back" size={24} color="#000" />
       </Pressable>
@@ -130,7 +127,7 @@ const styles = StyleSheet.create({
   },
   backButton: {
     position: "absolute",
-    top: Platform.OS === "ios" ? 50 : 30,
+    top: 60,
     left: 20,
     zIndex: 10,
   },

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -94,7 +94,6 @@ export default function SettingsScreen() {
           }}
         />
         <PrimaryButton title="Support Habee" onPress={handleSupport} />
-        <PrimaryButton title="Log Out" onPress={handleLogout} />
         <View>
           <Pressable
             style={styles.aboutButton}
@@ -127,6 +126,7 @@ Habee focuses on simplicity, visual progress, and an ad-free experience. Support
             </View>
           )}
         </View>
+        <PrimaryButton title="Log Out" onPress={handleLogout} />
         <PrimaryButton
           title="Delete Account"
           onPress={handleDeleteAccount}


### PR DESCRIPTION
## Summary
- Ensure Android reminder time is saved immediately without extra confirmation and hide save button for custom reminders
- Add Android-only back icons to habit creation, editing, and notification settings modals

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt` *(fails: No such file or directory)*
- `pytest -q`
- `npm ci` *(fails: Missing package-lock.json)*
- `npm install`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689fa7ac59788330bba1bba00872a526